### PR TITLE
Chronological Ordering of appointments

### DIFF
--- a/src/main/java/seedu/homerce/logic/commands/expense/BreakdownExpenseCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/expense/BreakdownExpenseCommand.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 
 import seedu.homerce.logic.commands.Command;
 import seedu.homerce.logic.commands.CommandResult;
+import seedu.homerce.model.HistoryManager;
 import seedu.homerce.model.Model;
 import seedu.homerce.model.expense.Expense;
 import seedu.homerce.model.expense.predicate.ExpenseMonthPredicate;
@@ -44,7 +45,7 @@ public class BreakdownExpenseCommand extends Command {
     }
 
     @Override
-    public CommandResult execute(Model model) {
+    public CommandResult execute(Model model, HistoryManager historyManager) {
         requireNonNull(model);
         List<Expense> filteredExpenseList = createFilteredExpense(model);
         Map<String, Double> expenseMap = breakdownExpenses(filteredExpenseList);

--- a/src/main/java/seedu/homerce/model/appointment/TimeOfDay.java
+++ b/src/main/java/seedu/homerce/model/appointment/TimeOfDay.java
@@ -59,4 +59,8 @@ public class TimeOfDay {
     public String toUiString() {
         return value.format(FORMAT_OUTPUT);
     }
+
+    public LocalTime getLocalTime() {
+        return value;
+    }
 }

--- a/src/main/java/seedu/homerce/model/appointment/UniqueAppointmentList.java
+++ b/src/main/java/seedu/homerce/model/appointment/UniqueAppointmentList.java
@@ -1,7 +1,0 @@
-package seedu.homerce.model.appointment;
-
-import seedu.homerce.model.util.uniquelist.UniqueList;
-
-public class UniqueAppointmentList extends UniqueList<Appointment> {
-
-}

--- a/src/main/java/seedu/homerce/model/appointment/uniquelist/AppointmentComparator.java
+++ b/src/main/java/seedu/homerce/model/appointment/uniquelist/AppointmentComparator.java
@@ -1,0 +1,16 @@
+package seedu.homerce.model.appointment.uniquelist;
+
+import java.util.Comparator;
+
+import seedu.homerce.model.appointment.Appointment;
+
+public class AppointmentComparator implements Comparator<Appointment> {
+    @Override
+    public int compare(Appointment t1, Appointment t2) {
+        if (t1.getAppointmentDate().equals(t2.getAppointmentDate())) {
+            return t1.getAppointmentTime().getLocalTime().compareTo(t2.getAppointmentTime().getLocalTime());
+        } else {
+            return t1.getAppointmentDate().getLocalDate().compareTo(t2.getAppointmentDate().getLocalDate());
+        }
+    }
+}

--- a/src/main/java/seedu/homerce/model/appointment/uniquelist/UniqueAppointmentList.java
+++ b/src/main/java/seedu/homerce/model/appointment/uniquelist/UniqueAppointmentList.java
@@ -1,0 +1,43 @@
+package seedu.homerce.model.appointment.uniquelist;
+
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.homerce.model.appointment.Appointment;
+import seedu.homerce.model.util.uniquelist.UniqueList;
+
+/**
+ * Extension of Unique list to accommodate appointments. Sorts based on date and time
+ * whenever new entries are added into the list.
+ */
+public class UniqueAppointmentList extends UniqueList<Appointment> {
+    private final AppointmentComparator appointmentComparator = new AppointmentComparator();
+    @Override
+    public void add(Appointment toAdd) {
+        super.add(toAdd);
+        FXCollections.sort(internalList, appointmentComparator);
+    }
+
+    @Override
+    public void setItem(Appointment target, Appointment edited) {
+        super.setItem(target, edited);
+        FXCollections.sort(internalList, appointmentComparator);
+    }
+
+    @Override
+    public void setItems(UniqueList<Appointment> replacement) {
+        super.setItems(replacement);
+        FXCollections.sort(internalList, appointmentComparator);
+    }
+
+    @Override
+    public void setItems(List<Appointment> items) {
+        super.setItems(items);
+        FXCollections.sort(internalList, appointmentComparator);
+    }
+
+    public ObservableList<Appointment> asModifiableList() {
+        return internalList;
+    }
+}

--- a/src/main/java/seedu/homerce/model/manager/AppointmentManager.java
+++ b/src/main/java/seedu/homerce/model/manager/AppointmentManager.java
@@ -8,24 +8,24 @@ import java.util.stream.Collectors;
 
 import javafx.collections.ObservableList;
 import seedu.homerce.model.appointment.Appointment;
-import seedu.homerce.model.util.uniquelist.UniqueList;
+import seedu.homerce.model.appointment.uniquelist.UniqueAppointmentList;
 
 /**
  * Wraps all data at the AppointmentManager level
  * Duplicates are not allowed (by .equals comparison)
  */
 public class AppointmentManager implements ReadOnlyAppointmentManager {
-    private final UniqueList<Appointment> appointments;
+    private final UniqueAppointmentList appointments;
 
     public AppointmentManager() {
-        this.appointments = new UniqueList<>();
+        this.appointments = new UniqueAppointmentList();
     }
 
     /**
      * Creates an AppointmentManager using the Appointments in the {@code toBeCopied}
      */
     public AppointmentManager(ReadOnlyAppointmentManager toBeCopied) {
-        this.appointments = new UniqueList<>();
+        this.appointments = new UniqueAppointmentList();
         resetData(toBeCopied);
     }
 
@@ -95,7 +95,7 @@ public class AppointmentManager implements ReadOnlyAppointmentManager {
 
     @Override
     public ObservableList<Appointment> getAppointmentList() {
-        return appointments.asUnmodifiableObservableList();
+        return appointments.asModifiableList();
     }
 
     @Override

--- a/src/main/java/seedu/homerce/model/util/attributes/Date.java
+++ b/src/main/java/seedu/homerce/model/util/attributes/Date.java
@@ -48,6 +48,10 @@ public class Date {
         return date.getYear();
     }
 
+    public LocalDate getLocalDate() {
+        return date;
+    }
+
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object


### PR DESCRIPTION
Implementation details: When appointments are added or edited, the `add` method or `setItem` method in UniqueList is called. I extended UniqueList to override these methods such that they are sorted by the comparator every time a change is made. This is a workaround as there is no convenient PriorityQueue available from FXCollections. 

Also, I changed `getAppointmentList()` in AppointmentManager.java such that the `internalList` is returned rather than the `internalUnmodifiableList`. This is inevitable as we cannot sort unmodifiable lists. Not sure what are the implications of this, seems fine at the moment (maybe can ask Jeffry).