### PR TITLE
Change behavior of edit commands for all list managers.

### DIFF
--- a/src/main/java/seedu/homerce/logic/commands/appointment/DoneAppointmentCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/appointment/DoneAppointmentCommand.java
@@ -48,7 +48,6 @@ public class DoneAppointmentCommand extends Command {
             appointmentToMarkDone.getAppointmentDate()
         );
         model.addRevenue(revenueToAdd);
-        model.updateFilteredAppointmentList(Model.PREDICATE_SHOW_ALL_APPOINTMENTS);
         model.refreshSchedule();
         return new CommandResult(
             String.format(MESSAGE_DONE_APPOINTMENT_SUCCESS, appointmentToMarkDone)

--- a/src/main/java/seedu/homerce/logic/commands/appointment/EditAppointmentCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/appointment/EditAppointmentCommand.java
@@ -5,7 +5,6 @@ import static seedu.homerce.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_SERVICE_SERVICE_CODE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_TIME_OF_DAY;
-import static seedu.homerce.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 
 import java.util.List;
 import java.util.Optional;
@@ -87,7 +86,6 @@ public class EditAppointmentCommand extends Command {
         }
 
         model.setAppointment(appointmentToEdit, editedAppointment);
-        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
         model.refreshSchedule();
         return new CommandResult(String.format(MESSAGE_EDIT_APPOINTMENT_SUCCESS, editedAppointment));
     }

--- a/src/main/java/seedu/homerce/logic/commands/appointment/UnDoneAppointmentCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/appointment/UnDoneAppointmentCommand.java
@@ -55,7 +55,6 @@ public class UnDoneAppointmentCommand extends Command {
         } else {
             deletionOfRevenueResult = MESSAGE_FAILED_TO_DELETE_REVENUE;
         }
-        model.updateFilteredAppointmentList(Model.PREDICATE_SHOW_ALL_APPOINTMENTS);
         model.refreshSchedule();
         return new CommandResult(
             String.format(MESSAGE_UNDONE_APPOINTMENT_SUCCESS, appointmentToMarkUnDone)

--- a/src/main/java/seedu/homerce/logic/commands/client/EditClientCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/client/EditClientCommand.java
@@ -5,7 +5,6 @@ import static seedu.homerce.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.homerce.model.Model.PREDICATE_SHOW_ALL_CLIENTS;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -83,7 +82,6 @@ public class EditClientCommand extends Command {
         }
 
         model.setClient(clientToEdit, editedClient);
-        model.updateFilteredClientList(PREDICATE_SHOW_ALL_CLIENTS);
         return new CommandResult(String.format(MESSAGE_EDIT_CLIENT_SUCCESS, editedClient), ClientListPanel.TAB_NAME);
     }
 

--- a/src/main/java/seedu/homerce/logic/commands/expense/EditExpenseCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/expense/EditExpenseCommand.java
@@ -6,7 +6,6 @@ import static seedu.homerce.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_ISFIXED;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_TAG;
-import static seedu.homerce.model.Model.PREDICATE_SHOW_ALL_EXPENSES;
 
 import java.util.List;
 import java.util.Optional;
@@ -81,7 +80,6 @@ public class EditExpenseCommand extends Command {
         }
 
         model.setExpense(expenseToEdit, editedExpense);
-        model.updateFilteredExpenseList(PREDICATE_SHOW_ALL_EXPENSES);
         return new CommandResult(String.format(MESSAGE_EDIT_EXPENSE_SUCCESS, editedExpense));
     }
 

--- a/src/main/java/seedu/homerce/logic/commands/service/EditServiceCommand.java
+++ b/src/main/java/seedu/homerce/logic/commands/service/EditServiceCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_SERVICE_DURATION;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_SERVICE_PRICE;
 import static seedu.homerce.logic.parser.CliSyntax.PREFIX_SERVICE_TITLE;
-import static seedu.homerce.model.Model.PREDICATE_SHOW_ALL_SERVICES;
 
 import java.util.List;
 import java.util.Optional;
@@ -78,7 +77,6 @@ public class EditServiceCommand extends Command {
         }
 
         model.setService(serviceToEdit, editedService);
-        model.updateFilteredServiceList(PREDICATE_SHOW_ALL_SERVICES);
         return new CommandResult(String.format(MESSAGE_EDIT_SERVICE_SUCCESS, editedService));
     }
 

--- a/src/test/java/seedu/homerce/logic/commands/client/EditClientCommandTest.java
+++ b/src/test/java/seedu/homerce/logic/commands/client/EditClientCommandTest.java
@@ -101,11 +101,7 @@ public class EditClientCommandTest {
 
         String expectedMessage = String.format(EditClientCommand.MESSAGE_EDIT_CLIENT_SUCCESS, editedClient);
 
-        Model expectedModel = new ModelManager(new UserPrefs(), new ClientManager(model.getClientManager()),
-            new ServiceManager(), new RevenueTracker(), new ExpenseTracker(), new AppointmentManager());
-        expectedModel.setClient(model.getFilteredClientList().get(0), editedClient);
-
-        assertCommandSuccess(editClientCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editClientCommand, model, expectedMessage, model);
     }
 
     @Test

--- a/src/test/java/seedu/homerce/logic/commands/service/EditServiceCommandTest.java
+++ b/src/test/java/seedu/homerce/logic/commands/service/EditServiceCommandTest.java
@@ -104,12 +104,7 @@ public class EditServiceCommandTest {
 
         String expectedMessage = String.format(EditServiceCommand.MESSAGE_EDIT_SERVICE_SUCCESS, editedService);
 
-        Model expectedModel = new ModelManager(new UserPrefs(), new ClientManager(),
-            new ServiceManager(model.getServiceManager()), new RevenueTracker(),
-            new ExpenseTracker(), new AppointmentManager());
-        expectedModel.setService(model.getFilteredServiceList().get(0), editedService);
-
-        assertCommandSuccess(editServiceCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(editServiceCommand, model, expectedMessage, model);
     }
 
     @Test


### PR DESCRIPTION
closes #262 

Changed the behavior of edit commands for all list managers and trackers, as well as `done` and `undone` commands - It will not update the list to show all items after editing, instead, the list state will remain as is.